### PR TITLE
Db 888 round2

### DIFF
--- a/lib/ABCInfo.pm
+++ b/lib/ABCInfo.pm
@@ -5,7 +5,7 @@ use warnings;
 
 require Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT = qw(get_topic_entity_tag_source_data);
+our @EXPORT = qw(get_topic_entity_tag_source_data get_AGRKB_for_FBrf);
 
 use JSON::PP;
 
@@ -27,7 +27,7 @@ sub get_topic_entity_tag_source_data {
 
 	Title:    get_topic_entity_tag_source_data
 	Usage:    get_topic_entity_tag_source_data(API_type, curator_type);
-	Function: The get_topic_entity_tag_source_data subroutine gets json that describes the topic_entity_tag_source information, using a curl command to query the relevant Alliance REST API service
+	Function: The get_topic_entity_tag_source_data subroutine gets json that describes the topic_entity_tag_source information, using a curl command to query the relevant Alliance REST API service, and returns that information as a reference.
 	Example: my $source_data = &get_topic_entity_tag_source_data('production', 'curator');
 
 	
@@ -36,8 +36,6 @@ Arguments:
 o API_type: the 'type' of the relevant Alliance REST API service to query - must be either 'production' or 'stage'
 
 o curator_type: the type of curation that you want the json details for - must be either 'curator' or 'author'
-
-o Returns the appropriate source information as a reference
 
 
 =cut
@@ -52,7 +50,7 @@ o Returns the appropriate source information as a reference
 
 	unless ($API_type eq 'production' | $API_type eq 'stage') {
 
-		die "unrecognized value ($API_type) passed to get_topic_entity_tag_source_data surboutine as API_type: must be 'production' or 'stage'\n";
+		die "unrecognized value ($API_type) passed to get_topic_entity_tag_source_data subroutine as API_type: must be 'production' or 'stage'\n";
 
 
 	}
@@ -106,5 +104,78 @@ o Returns the appropriate source information as a reference
 
 
 	return ($result);
+
+}
+
+
+sub get_AGRKB_for_FBrf {
+
+
+
+=head1 SUBROUTINE:
+=cut
+
+=head1
+
+	Title:    get_AGRKB_for_FBrf
+	Usage:    get_AGRKB_for_FBrf(API_type, FBrf);
+	Function: The get_AGRKB_for_FBrf subroutine gets the corresponding AGRKB number for the FBrf number supplied as the second argument, by using a curl command to query the relevant Alliance REST API service.
+	Example: my $AGRKB_data = &get_AGRKB_for_FBrf('production', 'FBrf0111489');
+
+
+Arguments:
+
+o API_type: the 'type' of the relevant Alliance REST API service to query - must be either 'production' or 'stage'
+
+o FBrf: the FBrf number for which the AGRKB number is needed.
+
+
+Returns:
+
+o Corresponding AGRKB number.
+
+=cut
+
+	unless (@_ == 2) {
+
+		die "Wrong number of parameters passed to the get_AGRKB_for_FBrf subroutine\n";
+	}
+
+	my ($API_type, $FBrf) = @_;
+
+	unless ($API_type eq 'production' | $API_type eq 'stage') {
+
+		die "unrecognized value ($API_type) passed to get_AGRKB_for_FBrf surboutine as API_type: must be 'production' or 'stage'\n";
+
+
+	}
+
+	unless ($FBrf =~ m/^FBrf[0-9]{7}$/) {
+		die "FBrf number passed to get_AGRKB_for_FBrf subroutine ($FBrf) is not correct format\n";
+
+	}
+
+	my $cmd = '';
+
+	if ($API_type eq 'stage') {
+
+		$cmd = "curl -X 'GET' 'https://stage-literature-rest.alliancegenome.org/cross_reference/FB%3A$FBrf' -H 'accept: application/json'";
+
+	} else {
+
+		$cmd = "curl -X 'GET' 'https://literature-rest.alliancegenome.org/cross_reference/FB%3A$FBrf' -H 'accept: application/json'";
+
+	}
+
+# fetch the data and convert the json to a reference
+	my $raw_json =`$cmd`;
+
+	my $json_encoder = JSON::PP->new()->canonical(1);
+	my $result = $json_encoder->decode($raw_json);
+
+	my $AGRKB = $result->{reference_curie};
+
+	return ($AGRKB);
+
 
 }

--- a/lib/ABCInfo.pm
+++ b/lib/ABCInfo.pm
@@ -1,0 +1,110 @@
+package ABCInfo;
+
+use strict;
+use warnings;
+
+require Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT = qw(get_topic_entity_tag_source_data);
+
+use JSON::PP;
+
+=head1 MODULE: AuditTable
+
+Module containing subroutines that get information from the ABC.
+
+=cut
+
+1;
+
+
+sub get_topic_entity_tag_source_data {
+
+=head1 SUBROUTINE:
+=cut
+
+=head1
+
+	Title:    get_topic_entity_tag_source_data
+	Usage:    get_topic_entity_tag_source_data(API_type, curator_type);
+	Function: The get_topic_entity_tag_source_data subroutine gets json that describes the topic_entity_tag_source information, using a curl command to query the relevant Alliance REST API service
+	Example: my $source_data = &get_topic_entity_tag_source_data('production', 'curator');
+
+	
+Arguments:
+
+o API_type: the 'type' of the relevant Alliance REST API service to query - must be either 'production' or 'stage'
+
+o curator_type: the type of curation that you want the json details for - must be either 'curator' or 'author'
+
+o Returns the appropriate source information as a reference
+
+
+=cut
+
+
+	unless (@_ == 2) {
+
+		die "Wrong number of parameters passed to the get_topic_entity_tag_source_data subroutine\n";
+	}
+
+	my ($API_type, $curator_type) = @_;
+
+	unless ($API_type eq 'production' | $API_type eq 'stage') {
+
+		die "unrecognized value ($API_type) passed to get_topic_entity_tag_source_data surboutine as API_type: must be 'production' or 'stage'\n";
+
+
+	}
+
+
+	my $curator_type_mapping = {
+
+# For manual curation, use: ATP:0000036 = 'documented statement evidence used in manual assertion by professional biocurator'
+
+		'curator' => {
+
+			'evidence' => '0000036',
+			'source_method' => 'FlyBase_curation',
+
+		},
+# For community curation, use: ATP:0000035 = 'documented statement evidence used in manual assertion by author'
+
+		'author' => {
+
+			'evidence' => '0000035',
+			'source_method' => 'author_first_pass',
+
+		},
+
+	};
+
+	unless (exists $curator_type_mapping->{$curator_type}) {
+
+		die "unrecognized value ($curator_type) passed to get_topic_entity_tag_source_data subroutine as curator_type: must be 'curator' or 'author'\n";
+
+
+	}
+
+	my $cmd = '';
+
+	if ($API_type eq 'stage') {
+
+		$cmd = "curl -X 'GET' 'https://stage-literature-rest.alliancegenome.org/topic_entity_tag/source/ATP%3A$curator_type_mapping->{$curator_type}->{evidence}/$curator_type_mapping->{$curator_type}->{source_method}/FB/FB' -H 'accept: application/json'";
+
+	} else {
+
+		$cmd = "curl -X 'GET' 'https://literature-rest.alliancegenome.org/topic_entity_tag/source/ATP%3A$curator_type_mapping->{$curator_type}->{evidence}/$curator_type_mapping->{$curator_type}->{source_method}/FB/FB' -H 'accept: application/json'";
+
+	}
+
+# fetch the data and convert the json to a reference
+	my $raw_json =`$cmd`;
+
+	my $json_encoder = JSON::PP->new()->canonical(1);
+	my $result = $json_encoder->decode($raw_json);
+
+
+	return ($result);
+
+}

--- a/lib/AuditTable.pm
+++ b/lib/AuditTable.pm
@@ -1,0 +1,132 @@
+package AuditTable;
+
+use strict;
+use warnings;
+
+require Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT = qw(get_relevant_curator);
+
+
+=head1 MODULE: AuditTable
+
+Module containing subroutines that get information from audit_chado table.
+
+=cut
+
+
+1;
+
+sub get_relevant_curator {
+
+=head1 SUBROUTINE:
+=cut
+
+=head1
+
+	Title:    get_relevant_curator
+	Usage:    get_relevant_curator(database handle, pub_id of reference, timestamp information to be matched);
+	Function: The get_relevant_curator subroutine takes audit_chado table timestamp information to be matched (e.g. timestamp for a particular triage flag) and the pub_id of the relevant reference and tries to find a matching 'curated_by' pubprop for that pub_id (ie. one with the same audit_chado table timestamp). If it finds any matches, it returns a data structure containing the relevant information from all matching 'curated_by' pubprop(s), otherwise it returns undef.
+	Example: my ($curator, $file) = &get_relevant_curator($dbh, $pub_id, $flag_audit_timestamp);
+
+	
+	For each matching curated_by pubprop it captures the 'Curator:' portion ($curator) and Proforma:' portion ($record_number) of the pubprop value and stores it as follows
+
+	It captures the following information:
+
+	o Count of the number of matching curated_by pubprops:
+
+		$data->{count}++;
+
+	o Count of number of matching curated_by pubprops where the $curator is a FlyBase curator (and not community/UniProt curation)
+
+		$data->{FB_curator_count}++;
+
+	o A $data->{curator} hash structure that captures $curator and $record_number info for all matching pubprops (used when there is more than one matching pubprop)
+
+		$data->{curator}->{$curator}->{$record_number}++;
+
+
+	o Two 'relevant' shortcut key-value pairs that capture the $curator and $record_number info for the last matching pubprop - **NB: these are only safe to use to if $data->{count} == 1, otherwise need to use the $data->{curator} hash structure**
+
+		$data->{relevant_curator} = $curator;
+		$data->{relevant_record} = $record_number;
+
+
+
+
+=cut
+
+	unless (@_ == 3) {
+
+		die "Wrong number of parameters passed to the get_relevant_curator subroutine\n";
+	}
+
+
+
+	my ($dbh, $pub_id, $audit_timestamp_to_match) = @_;
+
+	my ($relevant_curator , $relevant_record) = '', 
+
+	my $sql_query=sprintf("select distinct pp.value, ac.transaction_timestamp, pp.pubprop_id from  pubprop pp, cvterm c, audit_chado ac  where ac.audited_table='pubprop' and ac.audit_transaction='I' and pp.pubprop_id=ac.record_pkey and pp.pub_id=%s and c.cvterm_id=pp.type_id and c.name in ('curated_by')", $pub_id);
+
+	my $db_query = $dbh->prepare ($sql_query);
+	$db_query->execute or die "CAN'T GET curator info FROM CHADO:\n$sql_query\n";
+
+	my $data = undef;
+
+	while (my ($curated_by_value, $curated_by_audit_timestamp, $curated_by_pubprop_id) = $db_query->fetchrow_array()) {
+
+		if ($curated_by_value =~ m/^Curator: (.+?);Proforma: (.+?);timelastmodified: (.*)$/) {
+
+			my $curator = $1;
+			my $record_number = $2;
+			my $timelastmodified = $3;
+
+
+
+			if ($curated_by_audit_timestamp eq $audit_timestamp_to_match){
+
+				### commented out original code that was checking and converting format of 'timelastmodified' part of pubprop as not using this timestamp when submitting data:
+				### - using audit_chado timestamp information instead to be consistent with what has been done in alliance-linkml-flybase work
+				#my $time_from_curator;
+				# well behaved time format: Thu Mar 17 08:24:07 2011
+				#if ($timelastmodified =~ m/([A-Za-z]+)\s+([A-Za-z]+)\s+(\d+)\s+(\d+:\d+:\d+)\s+(\d+)/) {
+					#$time_from_curator= Time::Piece->strptime($timelastmodified, '%a %b %d %H:%M:%S %Y')->ymd("-");
+					#$time_from_curator.=" ".$4;
+				# incorrect time format that cannot be converted by Time::Piece: Thu 29 Oct 2020 09:13:21 AM EDT
+				# have to convert to correct order first, before run through Time::Piece
+				#} elsif ($timelastmodified =~ m/([a-zA-Z]+)\s+(\d+)\s+([a-zA-Z]+)\s+(\d+)\s+(\d+:\d+:\d+)\s+([A-Z]+)\s+([A-Z]+)/) {
+					#my @temp=split(/\s+/, $timelastmodified);
+					#my $time_before=$temp[0]." ".$temp[2]." ".$temp[1]." ".$temp[4]." ".$temp[3];
+					#$time_from_curator= Time::Piece->strptime($time_before, '%a %b %d %H:%M:%S %Y')->ymd("-");
+					#$time_from_curator.=" ".$temp[4];
+				#} else {
+					#print "ERROR: weird curated_by time format:$pub_id $curated_by_value\n";
+					#next;
+				#}
+				###
+
+				$relevant_curator = $curator;
+				$relevant_record = $record_number;
+				$data->{curator}->{$curator}->{$record_number}++;
+				$data->{count}++;
+				$data->{relevant_curator} = $curator;
+				$data->{relevant_record} = $record_number;
+
+				unless ($curator eq 'Author Submission' || $curator eq 'User Submission' || $curator eq 'UniProtKB') {
+
+					$data->{FB_curator_count}++;
+				}
+
+			}
+		} else {
+			# not expecting to trip this error
+			print "ERROR: wrong curated_by pubprop format for pub_id: $pub_id, pubprop: $curated_by_value\n";
+		}
+
+
+	}
+
+	return ($data);
+}

--- a/ticket_scrum-3147-topic-entity-tag.pl
+++ b/ticket_scrum-3147-topic-entity-tag.pl
@@ -104,12 +104,9 @@ otherwise for any other ‘Created by’ value , you should use: test: 223 stage
 
 
 
+2. The system call to actually run the $cmd to POST the data to a server is currently commented out. In addition, need to add a test to check that the system call completes successfully and to print an error if not.
 
-2. some values in the $flag_mapping hash are temporary place holders (have asked for new ATP terms) so will need replacing before being run for real.
-
-3. The system call to actually run the $cmd to POST the data to a server is currently commented out. In addition, need to add a test to check that the system call completes successfully and to print an error if not.
-
-4. the script currently requires an input file (given in 5th argument) that maps FBrf numbres to AGKRB numbers. Investigate whether its possible to submit the json using FBrf (I assume not) or whether could use GET to get the AGKRB for each required FBrf (this might make it to slow as its all FBrfs ?!)
+3. the script currently requires an input file (given in 5th argument) that maps FBrf numbres to AGKRB numbers. Investigate whether its possible to submit the json using FBrf (I assume not) or whether could use GET to get the AGKRB for each required FBrf (this might make it to slow as its all FBrfs ?!)
 
 
 the instructions to make the currently required input file are:
@@ -260,39 +257,25 @@ my $flag_mapping = {
 			'ATP_topic' => 'ATP:0000042',
 		},
 
-# place holder where have asked for new ATP term, will need to update ATP_topic with ATP term id
 
 		'merge' => {
 
-			'ATP_topic' => 'ATP:merge',
+			'ATP_topic' => 'ATP:0000340',
 			'species' => 'NCBITaxon:7214', # Drosophilidae
 			# not curator only - was in original version of FTYP
 		},
 
 		'split' => {
 
-			'ATP_topic' => 'ATP:split',
+			'ATP_topic' => 'ATP:0000341',
 			'species' => 'NCBITaxon:7214', # Drosophilidae
 		},
 
 		'new_char' => {
 
-			'ATP_topic' => 'ATP:new_char',
+			'ATP_topic' => 'ATP:0000339',
 			'species' => 'NCBITaxon:7214', # Drosophilidae
 		},
-
-# place holder - nocur will not be mapped to a topic tag, but to curation status in Alliance in some way
-# this may happen in this script, or a different one. adding in now so it doesn't get forgotten and for testing
-
-		'nocur' => {
-
-			'ATP_topic' => 'ATP:nocur',
-			'species' => 'NCBITaxon:7214', # Drosophilidae
-			'negated' => '1',
-			'curator_only' => '1',
-		},
-
-
 
 	},
 
@@ -424,10 +407,8 @@ my $flag_mapping = {
 			'ATP_topic' => 'ATP:0000041',
 		},
 
-# place holder where have asked for new ATP term, will need to update ATP_topic with ATP term id
-
 		'neur_exp' => {
-			'ATP_topic' => 'ATP:neur_exp',
+			'ATP_topic' => 'ATP:0000338',
 			'curator_only' => '1',
 		},
 
@@ -475,6 +456,8 @@ my $flags_to_ignore = {
 		'GO_cur' => '1',
 		'GOcur' => '1',
 		'noGOcur' => '1',
+
+		'nocur' => '1', # nocur will not be added as a topic, but will instead be added to the curation status information in the workflow editor in the Alliance
 	},
 
 	'harv_flag' => {

--- a/ticket_scrum-3147-topic-entity-tag.pl
+++ b/ticket_scrum-3147-topic-entity-tag.pl
@@ -195,7 +195,7 @@ if ($ENV_STATE eq "dev") {
 # ATP_topic is compulsory for every flag
 # other keys are optional
 # species only present if it differs from default Dmel (NCBITaxon:7227) for that flag
-# data_novelty only present if it applies to that flag
+# data_novelty only present if the FB triage flag indicates 'new' data of some kind
 # negated only present if it applies to that flag
 my $flag_mapping = {
 
@@ -653,10 +653,7 @@ foreach my $FBrf (sort keys %FBrf_pubid){
 
 					$data->{novel_topic_data} = exists $flag_mapping->{$flag_source}->{$flag_type}->{data_novelty} ? 1 : 0;
 
-					if (exists $flag_mapping->{$flag_source}->{$flag_type}->{data_novelty}) {
-
-						$data->{data_novelty} = $flag_mapping->{$flag_source}->{$flag_type}->{data_novelty};
-					}
+					$data->{data_novelty} = exists $flag_mapping->{$flag_source}->{$flag_type}->{data_novelty} ? $flag_mapping->{$flag_source}->{$flag_type}->{data_novelty} : 'ATP:0000335'; # if the mapping hash has no specific data novelty term set, the parent term (ATP:0000335 = 'data novelty') must be added for ABC validation purposes
 
 					#choose different topic_entity_tag_source_id based on ENV_STATE and 'created_by' value
 					if ($curator eq "Author Submission" || $curator eq "User Submission"){

--- a/ticket_scrum-3147-topic-entity-tag.pl
+++ b/ticket_scrum-3147-topic-entity-tag.pl
@@ -7,6 +7,15 @@ use Time::Piece;
 
 use JSON::PP;
 
+use File::Basename;
+use File::Spec;
+
+# add lib sub-folder containing modules into @INC
+# has to be done this way - cannot assign  File::Basename::dirname(File::Spec->rel2abs($0) (which is directory script lives in) to a variable and then put that in the 'use lib' line, because the use lib line is done at compile time, not run time
+use lib File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs($0)), 'lib');
+
+# add modules from lib-subfolder
+use AuditTable;
 
 =head1 NAME ticket_scrum-3147-topic-entity-tag.pl
 
@@ -57,7 +66,7 @@ Script logic:
 
 3b. For the remaining flags, the script tries to find the matching curator from the 'curated_by' pubprop for that pub_id by comparing audit_chado timestamps.
 
-- the get_relevant_curator subroutine first gets all matching 'curated_by' pubprops with the same audit_chado 'I' timestamp as the triage flag and then:
+- the AuditTable::get_relevant_curator subroutine first gets all matching 'curated_by' pubprops with the same audit_chado 'I' timestamp as the triage flag and then:
 
 - if a single match is found, that curator is used.
 
@@ -569,7 +578,7 @@ foreach my $FBrf (sort keys %FBrf_pubid){
 
 
 				# 2. try to find the relevant curator (from curated_by pubprop) using audit table timestamp information
-				my $curator_data = &get_relevant_curator($dbh, $pub_id, $flag_audit_timestamp);
+				my $curator_data = &AuditTable::get_relevant_curator($dbh, $pub_id, $flag_audit_timestamp);
 				my $curator = ''; # this will be the relevant curator with a matching timestamp.
 				my $file = ''; # this will be the relevant curation record. Not submitted to the Alliance, but useful for plain text output (DATA: lines) when testing.
 
@@ -695,118 +704,5 @@ foreach my $FBrf (sort keys %FBrf_pubid){
 }
 
 
-sub get_relevant_curator {
-
-=head1 SUBROUTINE:
-=cut
-
-=head1
-
-	Title:    get_relevant_curator
-	Usage:    get_relevant_curator(database handle, pub_id of reference, timestamp information to be matched);
-	Function: The get_relevant_curator subroutine takes audit_chado table timestamp information to be matched (e.g. timestamp for a particular triage flag) and the pub_id of the relevant reference and tries to find a matching 'curated_by' pubprop for that pub_id (ie. one with the same audit_chado table timestamp). If it finds any matches, it returns a data structure containing the relevant information from all matching 'curated_by' pubprop(s), otherwise it returns undef.
-	Example: my ($curator, $file) = &get_relevant_curator($dbh, $pub_id, $flag_audit_timestamp);
-
-	
-	For each matching curated_by pubprop it captures the 'Curator:' portion ($curator) and Proforma:' portion ($record_number) of the pubprop value and stores it as follows
-
-	It captures the following information:
-
-	o Count of the number of matching curated_by pubprops:
-
-		$data->{count}++;
-
-	o Count of number of matching curated_by pubprops where the $curator is a FlyBase curator (and not community/UniProt curation)
-
-		$data->{FB_curator_count}++;
-
-	o A $data->{curator} hash structure that captures $curator and $record_number info for all matching pubprops (used when there is more than one matching pubprop)
-
-		$data->{curator}->{$curator}->{$record_number}++;
-
-
-	o Two 'relevant' shortcut key-value pairs that capture the $curator and $record_number info for the last matching pubprop - **NB: these are only safe to use to if $data->{count} == 1, otherwise need to use the $data->{curator} hash structure**
-
-		$data->{relevant_curator} = $curator;
-		$data->{relevant_record} = $record_number;
-
-
-
-
-=cut
-
-	unless (@_ == 3) {
-
-		die "Wrong number of parameters passed to the get_relevant_curator subroutine\n";
-	}
-
-
-
-	my ($dbh, $pub_id, $audit_timestamp_to_match) = @_;
-
-	my ($relevant_curator , $relevant_record) = '', 
-
-	my $sql_query=sprintf("select distinct pp.value, ac.transaction_timestamp, pp.pubprop_id from  pubprop pp, cvterm c, audit_chado ac  where ac.audited_table='pubprop' and ac.audit_transaction='I' and pp.pubprop_id=ac.record_pkey and pp.pub_id=%s and c.cvterm_id=pp.type_id and c.name in ('curated_by')", $pub_id);
-
-	my $db_query = $dbh->prepare ($sql_query);
-	$db_query->execute or die" CAN'T GET curator info FROM CHADO:\n$sql_query\n";
-
-	my $data = undef;
-
-	while (my ($curated_by_value, $curated_by_audit_timestamp, $curated_by_pubprop_id) = $db_query->fetchrow_array()) {
-
-		if ($curated_by_value =~ m/^Curator: (.+?);Proforma: (.+?);timelastmodified: (.*)$/) {
-
-			my $curator = $1;
-			my $record_number = $2;
-			my $timelastmodified = $3;
-
-
-
-			if ($curated_by_audit_timestamp eq $audit_timestamp_to_match){
-
-				### commented out original code that was checking and converting format of 'timelastmodified' part of pubprop as not using this timestamp when submitting data:
-				### - using audit_chado timestamp information instead to be consistent with what has been done in alliance-linkml-flybase work
-				#my $time_from_curator;
-				# well behaved time format: Thu Mar 17 08:24:07 2011
-				#if ($timelastmodified =~ m/([A-Za-z]+)\s+([A-Za-z]+)\s+(\d+)\s+(\d+:\d+:\d+)\s+(\d+)/) {
-					#$time_from_curator= Time::Piece->strptime($timelastmodified, '%a %b %d %H:%M:%S %Y')->ymd("-");
-					#$time_from_curator.=" ".$4;
-				# incorrect time format that cannot be converted by Time::Piece: Thu 29 Oct 2020 09:13:21 AM EDT
-				# have to convert to correct order first, before run through Time::Piece
-				#} elsif ($timelastmodified =~ m/([a-zA-Z]+)\s+(\d+)\s+([a-zA-Z]+)\s+(\d+)\s+(\d+:\d+:\d+)\s+([A-Z]+)\s+([A-Z]+)/) {
-					#my @temp=split(/\s+/, $timelastmodified);
-					#my $time_before=$temp[0]." ".$temp[2]." ".$temp[1]." ".$temp[4]." ".$temp[3];
-					#$time_from_curator= Time::Piece->strptime($time_before, '%a %b %d %H:%M:%S %Y')->ymd("-");
-					#$time_from_curator.=" ".$temp[4];
-				#} else {
-					#print "ERROR: weird curated_by time format:$pub_id $curated_by_value\n";
-					#next;
-				#}
-				###
-
-				$relevant_curator = $curator;
-				$relevant_record = $record_number;
-				$data->{curator}->{$curator}->{$record_number}++;
-				$data->{count}++;
-				$data->{relevant_curator} = $curator;
-				$data->{relevant_record} = $record_number;
-
-				unless ($curator eq 'Author Submission' || $curator eq 'User Submission' || $curator eq 'UniProtKB') {
-
-					$data->{FB_curator_count}++;
-				}
-
-			}
-		} else {
-			# not expecting to trip this error
-			print "ERROR: wrong curated_by pubprop format for pub_id: $pub_id, pubprop: $curated_by_value\n";
-		}
-
-
-	}
-
-	return ($data);
-}
 
 


### PR DESCRIPTION
This pull request:

1. puts some subroutines into modules (AuditTable, ABCInfo), so that they will be easy to re-use for other scripts.

2. gets topic_entity_tag_source info from the relevant ABC database when the script is run (instead of hard-coding).

3. adds the default data novelty parent term (ATP:0000335) to each topic_entity_tag item if there is no other more specific child term to use for that topic.