### PR TITLE
changes to FB scripts that make TET info and curation status info json files

### DIFF
--- a/lib/AuditTable.pm
+++ b/lib/AuditTable.pm
@@ -497,6 +497,7 @@ Arguments:
 		'args' => '.+?\.args\..+?',
 		'phen' => '[a-z][a-z][0-9]{1,}\.phen',
 		'cam_full' => '(ma|sb|rd|sf|tj|al|sm|cm|pm|gm|ao|cp|lp|sp|sr|rs|ra|ds|ew|cy)[0-9]{1,}(\.(h|hf))?',
+		'humanhealth' => '.+?\.(hh|hh_multiple|hds|hds_multiple|hh_[0-9]{1,}|hds_rvw)\..+?',
 
 
 

--- a/lib/AuditTable.pm
+++ b/lib/AuditTable.pm
@@ -119,6 +119,12 @@ sub get_relevant_curator {
 					$data->{FB_curator_count}++;
 				}
 
+				if ($curator eq 'Author Submission' || $curator eq 'User Submission') {
+
+					$data->{community_curation_count}++;
+
+				}
+
 			}
 		} else {
 			# not expecting to trip this error

--- a/lib/Mappings.pm
+++ b/lib/Mappings.pm
@@ -64,11 +64,6 @@ sub get_flag_mapping {
 				'data_novelty' => 'ATP:0000229', # new to field
 			},
 
-
-			'gene_group' => {
-				'ATP_topic' => 'ATP:0000065',
-			},
-
 			'pathway' => {
 				'ATP_topic' => 'ATP:0000113',
 			},
@@ -419,6 +414,7 @@ sub get_flags_to_ignore {
 			'GO_cur' => '1',
 			'GOcur' => '1',
 			'noGOcur' => '1',
+			'gene_group' => '1',
 
 			'nocur' => '1', # nocur will not be added as a topic, but will instead be added to the curation status information in the workflow editor in the Alliance
 		},

--- a/lib/Mappings.pm
+++ b/lib/Mappings.pm
@@ -64,10 +64,6 @@ sub get_flag_mapping {
 				'data_novelty' => 'ATP:0000229', # new to field
 			},
 
-			'pathway' => {
-				'ATP_topic' => 'ATP:0000113',
-			},
-
 			'pert_exp' => {
 				'ATP_topic' => 'ATP:0000042',
 			},
@@ -415,6 +411,7 @@ sub get_flags_to_ignore {
 			'GOcur' => '1',
 			'noGOcur' => '1',
 			'gene_group' => '1',
+			'pathway' => '1',
 
 			'nocur' => '1', # nocur will not be added as a topic, but will instead be added to the curation status information in the workflow editor in the Alliance
 		},

--- a/lib/Mappings.pm
+++ b/lib/Mappings.pm
@@ -256,6 +256,12 @@ sub get_flag_mapping {
 
 				'ATP_topic' => 'ATP:0000011',# 'disease' ATP term - using more general ATP term for FBhh curation
 				'species' => 'NCBITaxon:7214', # Drosophilidae
+				'for_curation_status' => {
+					'suffix' => 'use',
+					'get_curated_data' => 'humanhealth',
+					'use_filename' => 'humanhealth',
+					'relevant_internal_note' => 'HDM flag not applicable',
+				},
 			},
 
 			# may decide not to submit this flag depending on whether FBhh curation will be done in Alliance (so may need deleting here and adding to ignore hash)
@@ -263,6 +269,12 @@ sub get_flag_mapping {
 
 				'ATP_topic' => 'ATP:0000011',# 'disease' ATP term - using more general ATP term for FBhh curation
 				'species' => 'NCBITaxon:7214', # Drosophilidae
+				'for_curation_status' => {
+					'suffix' => 'use',
+					'get_curated_data' => 'humanhealth',
+					'use_filename' => 'humanhealth',
+					'relevant_internal_note' => 'HDM flag not applicable',
+				},
 			},
 
 			'gene_model' => {

--- a/lib/Util.pm
+++ b/lib/Util.pm
@@ -149,6 +149,7 @@ o $data_type is the type of curated data. The value must be present as a key in 
 
 		'phys_int' => ['select distinct p.pub_id from pub p, interaction_pub ip, interaction i where p.is_obsolete = \'f\' and p.pub_id = ip.pub_id and ip.interaction_id = i.interaction_id and i.is_obsolete = \'f\''],
 		'cell_line' => ['select distinct p.pub_id from pub p, cell_line_pub cp, cell_line c where p.is_obsolete = \'f\' and p.pub_id = cp.pub_id and cp.cell_line_id = c.cell_line_id'],
+		'humanhealth' => ['select distinct p.pub_id from pub p, humanhealth hh, humanhealth_pub hhp where p.is_obsolete = \'f\' and p.pub_id = hhp.pub_id and hh.humanhealth_id = hhp.humanhealth_id and hh.is_obsolete = \'f\''],
 
 
 		'chemical' => ['select distinct p.pub_id from pub p, feature f, feature_pub fp where p.is_obsolete = \'f\' and p.pub_id = fp.pub_id and f.feature_id = fp.feature_id and f.is_obsolete = \'f\' and f.uniquename ~\'^FBch\''],
@@ -186,6 +187,7 @@ o $data_type is the type of curated data. The value must be present as a key in 
 				'select distinct p.pub_id from phendesc pd, pub p, genotype g where p.is_obsolete = \'f\' and p.pub_id = pd.pub_id and pd.genotype_id = g.genotype_id and g.is_obsolete = \'f\''
 
 ],
+
 
 	};
 

--- a/populate_topic_curation_status.pl
+++ b/populate_topic_curation_status.pl
@@ -814,7 +814,7 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 									} else {
 
 										# keep this warning - will identify any papers with missing 'No phenotypic data in paper' internal note
-										print $data_error_file "WARNING: no data despite standard filename (pheno loop): topic: $ATP, pub_id: $pub_id, $pub_id_to_FBrf->{$pub_id}->{'FBrf'}, $timestamp\n";
+										print $data_error_file "WARNING: no data despite standard filename (pheno loop) (check whether need to add a 'No phenotypic data in paper' internal note): topic: $ATP, pub_id: $pub_id, $pub_id_to_FBrf->{$pub_id}->{'FBrf'}, $timestamp\n";
 
 									}
 

--- a/populate_topic_curation_status.pl
+++ b/populate_topic_curation_status.pl
@@ -515,6 +515,10 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 
 												$store_status++;
 
+												if ($ATP eq 'ATP:0000011') {
+													$note = ''; # set 'HDM flag not applicable' note to empty for the small number of cases where added in error to publications with humanhealth data
+												}
+
 											} else {
 
 												# this represents cases where there is a DONE flag suffix but no corresponding curated data
@@ -570,6 +574,10 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 													unless ($note) {
 
 														$note = "'$suffix' flag suffix present in FB, indicating that the publication has been looked at, but there is no curated data of the relevant type in FB, so status set to 'won't curate' with a 'no curatable data' tag.";
+													} else {
+
+														$note = ''; # set 'HDM flag not applicable' note to empty as the information is captured in the curation status
+
 													}
 
 
@@ -744,12 +752,17 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 							if (exists $has_curated_data->{$pub_id}) {
 
 								$curation_status = 'ATP:0000239';
-
-								unless ($note) {
-									$note = "'curated' status inferred from presence of data plus currec with expected filename format.";
-
-								}
 								$store_status++;
+
+								if ($ATP eq 'ATP:0000011') {
+									$note = ''; # set 'HDM flag not applicable' note to empty for the small number of cases where added in error to publications with humanhealth data
+								}
+
+								# suppress following loop as was for debugging
+								#unless ($note) {
+								#	$note = "'curated' status inferred from presence of data plus currec with expected filename format.";
+								#}
+
 
 							} else {
 
@@ -767,7 +780,7 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 
 										} elsif ($note =~ m/already curated by/) {
 
-											$curation_status = 'ATP:0000299'; # won't curate !! need to check this is OK !!
+											$curation_status = 'ATP:0000299'; # won't curate
 											$store_status++;
 
 										} else {
@@ -790,6 +803,7 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 									if ($note) {
 										$curation_status = 'ATP:0000299'; # won't curate
 										$curation_tag = 'ATP:0000226'; # no curatable data
+										$note = ''; # set 'HDM flag not applicable' note to empty as the information is captured in the curation status
 										$store_status++;
 
 									}
@@ -802,14 +816,9 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 
 										if ($note =~ m/only pheno_chem data in paper/ || $note =~ m/No phenotypic data in paper/) {
 
-											# this loop is needed to remove an incorrect 'phen_cur: CV annotations only' tag that was added automatically to some records with no phenotypic information
-											if ($note =~m/phen_cur: CV annotations only. [a-z]{2}[0-9]{6}./) {
-												$note =~ s/phen_cur: CV annotations only. [a-z]{2}[0-9]{6}.//;
-
-											}
-
 											$curation_status = 'ATP:0000299'; # won't curate
 											$curation_tag = 'ATP:0000226'; # no curatable data
+											$note = ''; # set note to empty as the information is captured in the curation status
 											$store_status++;
 
 
@@ -973,10 +982,10 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 
 							}
 
-							unless ($note) {
-								$note = "'curated' status inferred from presence of data plus currec with expected filename format.";
-
-							}
+							# suppress following loop as was for debugging
+							#unless ($note) {
+							#	$note = "'curated' status inferred from presence of data plus currec with expected filename format.";
+							#}
 
 							$note =~ s/^ //;
 							$note =~ s/ $//;

--- a/populate_topic_curation_status.pl
+++ b/populate_topic_curation_status.pl
@@ -229,7 +229,7 @@ my $flag_suffix_mapping = {
 		'note' => 'Partial curation.',
 	},
 
-	'in progress' => {
+	'In progress' => {
 
 		'curation_status' => 'ATP:0000237', # 'curation in progress'
 	},
@@ -550,6 +550,19 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 													$note = $note . "'$suffix' flag suffix present in FB, indicating that the publication has been looked at, but there is no curated data of the relevant type in FB. Despite this, set status to 'curated' as attribution may be to a related personal communication (after author correspondence) instead of the original reference.";
 													$store_status++;
 
+												# loop to deal with humanhealth flags (harv_flag disease flags)
+												} elsif ($ATP eq 'ATP:0000011') {
+
+													$curation_status = 'ATP:0000299'; # won't curate
+													$curation_tag = 'ATP:0000226'; # no curatable data
+													$store_status++;
+
+													unless ($note) {
+
+														$note = "'$suffix' flag suffix present in FB, indicating that the publication has been looked at, but there is no curated data of the relevant type in FB, so status set to 'won't curate' with a 'no curatable data' tag.";
+													}
+
+
 												} else {
 													$curation_status = 'ATP:0000299'; # won't curate
 													$curation_tag = 'ATP:0000226'; # no curatable data
@@ -620,10 +633,10 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 
 							}
 
-							} else {
+						} else {
 
-								print $data_error_file "ERROR: unknown suffix type: topic: $ATP, pub_id: $pub_id, suffix: $suffix\n";
-							}
+							print $data_error_file "ERROR: unknown suffix type: topic: $ATP, pub_id: $pub_id, suffix: $suffix\n";
+						}
 					} else {
 						print $data_error_file "ERROR: more than one suffix type for single topic: topic: $ATP, pub_id: $pub_id\n";
 					}
@@ -757,6 +770,17 @@ foreach my $ATP (sort keys %{$curation_status_topics}) {
 									} else {
 
 										print $data_error_file "WARNING: no data despite standard filename (phys_int loop): topic: $ATP, pub_id: $pub_id, $pub_id_to_FBrf->{$pub_id}->{'FBrf'}, $timestamp\n";
+
+									}
+
+
+								# loop to deal with humanhealth flags (harv_flag disease flags)
+								} elsif ($ATP eq 'ATP:0000011') {
+
+									if ($note) {
+										$curation_status = 'ATP:0000299'; # won't curate
+										$curation_tag = 'ATP:0000226'; # no curatable data
+										$store_status++;
 
 									}
 
@@ -1052,7 +1076,7 @@ foreach my $pub_id (sort keys %{$diseaseHP_flags}) {
 
 				unless ($ENV_STATE eq 'production') {
 					print $plain_output_file "DATA:$pub_id\t$FBrf\t$pub_type\t$element->{'topic'}\t$flag\t$element->{'curation_status'}\t$element->{'date_created'}\t$element->{'curation_tag'}\t$note\t$element->{'created_by'}\n";
-			}
+				}
 			}
 
 

--- a/populate_topic_data.pl
+++ b/populate_topic_data.pl
@@ -2,10 +2,7 @@
 
 use strict;
 use warnings;
-#use XML::DOM;
 use DBI;
-use Digest::MD5  qw(md5 md5_hex md5_base64);
-use Time::Piece;
 
 use JSON::PP;
 

--- a/populate_topic_data.pl
+++ b/populate_topic_data.pl
@@ -291,14 +291,26 @@ foreach my $pub_id (sort keys %{$flag_info}) {
 					if (exists $flag_mapping->{$flag_type} && exists $flag_mapping->{$flag_type}->{$flag}) {
 
 
+						if (exists $flag_info->{$pub_id}->{$flag_type}->{$flag}->{'Inappropriate use of flag'}) {
+							next;
+						}
+
+
+						my $flag_audit_timestamp;
+						my $flag_suffix = '';
 						if (scalar keys %{$flag_info->{$pub_id}->{$flag_type}->{$flag}} == 1) {
 
-							my $flag_suffix = join '', keys %{$flag_info->{$pub_id}->{$flag_type}->{$flag}};
+							$flag_suffix = join '', keys %{$flag_info->{$pub_id}->{$flag_type}->{$flag}};
+						} else {
 
+							if (exists $flag_info->{$pub_id}->{$flag_type}->{$flag}->{'NO_SUFFIX'}) {
+								$flag_suffix = 'NO_SUFFIX';
 
-							if ($flag_suffix eq 'Inappropriate use of flag') {
-								next;
 							}
+						}
+
+						if ($flag_suffix ne '') {
+
 
 
 							# get the earliest timestamp for when the flag was inserted into chado
@@ -307,6 +319,8 @@ foreach my $pub_id (sort keys %{$flag_info}) {
 
 							# 2. try to find the relevant curator (from curated_by pubprop) using audit table timestamp information
 							my $curator_data = &get_relevant_curator($dbh, $pub_id, $flag_audit_timestamp);
+
+
 							my $curator = ''; # this will be the relevant curator with a matching timestamp.
 							my $file = ''; # this will be the relevant curation record. Not submitted to the Alliance, but useful for plain text output (DATA: lines) when testing.
 
@@ -434,7 +448,7 @@ foreach my $pub_id (sort keys %{$flag_info}) {
 
 						} else {
 
-							print $data_error_file "ERROR: more than one suffix type for single flag: $pub_id, $flag_type\n";
+							print $data_error_file "ERROR: more than one suffix type and no 'NO_SUFFIX' for single flag: $pub_id, $flag_type\n";
 
 
 						}

--- a/populate_topic_data.pl
+++ b/populate_topic_data.pl
@@ -107,7 +107,7 @@ Script logic:
 
 2b. splits the 'raw' triage flag into the flag part and the suffix part (splits on ::) (e.g. disease::DONE -> flag = disease, suffix = DONE).
 
-3. For each flag,
+3. For each triage flag,
 
 3a. the flag is ignored if it is in the $flags_to_ignore hash or it has a suffix and the suffix is 'Inappropriate use of flag' (which indicates the flag is incorrect).
 
@@ -121,14 +121,11 @@ Script logic:
 
 3c. If a matching curator was successfully identified, a data structure with the relevant information is made for that flag+FBrf combination, using the flag timestamp from audit_chado and mapping information in the $flag_mapping hash to fill out the data structure.
 
-3d. the data structure is then converted to json, and either printed (dev mode) or submitted to the appropriate ABC server using POST (all other modes).
 
+4. gets internal notes that contain 'Dataset: pheno' information, tries to identify the relevant curator (using same logic as for triage flags in 3.) and if a matching curator is successfully identified, adds the relevant information for each flag+FBrf combination to the same data structure used to store triage flag information in 3.
 
-=cut
+5. the data structure containing triage flag and 'Dataset: pheno' information is then converted to json, and either submitted to the appropriate ABC server using POST (test mode) or printed (all other modes).
 
-=head1 STILL TO DO
-
-1. The system call to actually run the $cmd to POST the data to a server is currently commented out. In addition, need to add a test to check that the system call completes successfully and to print an error if not.
 
 =cut
 
@@ -681,7 +678,7 @@ foreach my $pub_id (sort keys %{$dataset_pheno_data}) {
 
 	} else {
 
-		print $process_error_file "ERROR: 'Dataset: pheno '$pub_id with no FBrf in final mapping\n";
+		print $data_error_file "ERROR: 'Dataset: pheno '$pub_id with no FBrf in final mapping\n";
 
 	}
 }

--- a/populate_topic_data.pl
+++ b/populate_topic_data.pl
@@ -641,7 +641,7 @@ foreach my $pub_id (sort keys %{$dataset_pheno_note}) {
 				# also add any additional note text
 				if ($flag_count == 0) {
 
-					$dataset_pheno_data->{$pub_id}->{date_updated} = "$dataset_pheno_data->{$pub_id}->{created_by}";
+					$dataset_pheno_data->{$pub_id}->{updated_by} = "$dataset_pheno_data->{$pub_id}->{created_by}";
 					$dataset_pheno_data->{$pub_id}->{created_by} = $curator;
 					$dataset_pheno_data->{$pub_id}->{date_updated} = "$dataset_pheno_data->{$pub_id}->{date_created}";
 					$dataset_pheno_data->{$pub_id}->{date_created} = $line_timestamp;


### PR DESCRIPTION
Main changes are:


**A. populate_topic_data.pl script**

1. 'Dataset: pheno' FB internal note is now used to add the relevant Alliance ATP topic.

2. consistency checking for dis_flag related topics - if both negative  and positive flags are present for the same FBrf, does NOT add the flags to the json output, but instead adds a warning to the data_errors file so that the curation inconsistency can be fixed.

3. Can now cope if a flag for a given FBrf is present in both 'plain' form (eg. chemical) and with a suffix (e.g chemical::ONE) - the topic is added as long as the suffix is not 'Inappropriate use of flag' (which indicate the topic was added in error).



**B. populate_topic_curation_status.pl script.**


1. Curation status for *harv*_flag disease-related flags is now reported, including 'curation needed' status for uncurated high priority (diseaseHP) flagged papers (previously only *dis*_flag curation status was reported).

2. User can now specify a single FBrf (or regex) in 'dev' mode.

3. placeholder for 'high priority data' changed to ATP id (ATP:0000353)

4. removed redundant/debugging 'note' items from json output.

C. moved two flags to the 'ignore' hash as the existing FB data will not be exported to the Alliance:
- gene_group
- pathway
