### PR TITLE
Add endpt to json metadata

### DIFF
--- a/lib/Util.pm
+++ b/lib/Util.pm
@@ -29,18 +29,24 @@ sub make_abc_json_metadata {
 	Title:    make_abc_json_metadata
 	Usage:    make_abc_json_metadata(source database);
 	Function: The make_abc_json_metadata subroutine makes a reference containing standard information for a "metaData" json object for a json file containing data to be submitted to the ABC.
-	Example: my $json_metadata = &make_abc_json_metadata('production');
+	Example: my $json_metadata = &make_abc_json_metadata('production', 'curation_status');
+	Example: my $json_metadata = &make_abc_json_metadata($db, $api_endpoint);
         Args    : source database - the name of the FlyBase chado database used to make the file.
 
+Arguments:
+
+o $source - the name of the FlyBase chado database used to make the file.
+
+o $api_endpoint - the appropriate path (downstream of the base URL) to use for the Alliance Literature Service API when loading the json data into the ABC.
 
 =cut
 
-	unless (@_ == 1) {
+	unless (@_ == 2) {
 
 		die "Wrong number of parameters passed to the make_abc_json_metadata subroutine\n";
 	}
 
-	my ($source) = @_;
+	my ($source, $api_endpoint) = @_;
 
 	my $date_stamp = &get_yyyymmdd_date_stamp();
 
@@ -49,7 +55,7 @@ sub make_abc_json_metadata {
 		'dataProvider' => {
 
 			'mod' => 'FB',
-			'type' => 'curated', 
+			'type' => 'curated',
 		},
 
 	};
@@ -57,6 +63,7 @@ sub make_abc_json_metadata {
 	# copied format from agr_schemas/ingest/metaData.json
 	$metadata->{'dateProduced'} = $date_stamp;
 	$metadata->{'release'} = $source;
+	$metadata->{'endpoint'} = $api_endpoint;
 
 
 	return ($metadata);

--- a/populate_topic_curation_status.pl
+++ b/populate_topic_curation_status.pl
@@ -154,10 +154,10 @@ o For timestamps determined from curation record(s) with the standard filename f
 
 
 
-if (@ARGV != 5) {
-    warn "Wrong number of arguments, should be 5!\n";
-    warn "\n USAGE: $0 pg_server db_name pg_username pg_password dev|test|production\n\n";
-    warn "\teg: $0 flysql24 production_chado zhou pwd dev|test|production\n\n";
+if (@ARGV != 6) {
+    warn "Wrong number of arguments, should be 6!\n";
+    warn "\n USAGE: $0 pg_server db_name pg_username pg_password dev|test|production access_token\n\n";
+    warn "\teg: $0 flysql24 production_chado zhou pwd dev|test|production ABCD1234\n\n";
     exit;
 }
 
@@ -166,7 +166,7 @@ my $db = shift(@ARGV);
 my $user = shift(@ARGV);
 my $pwd = shift(@ARGV);
 my $ENV_STATE = shift(@ARGV);
-
+my $access_token = shift(@ARGV);
 
 unless ($ENV_STATE eq 'dev'|| $ENV_STATE eq 'test'|| $ENV_STATE eq 'production') {
 
@@ -176,7 +176,11 @@ unless ($ENV_STATE eq 'dev'|| $ENV_STATE eq 'test'|| $ENV_STATE eq 'production')
 }
 
 my $test_FBrf = '';
-my $okta_token = '';
+
+# variable that specifies the appropriate path (downstream of the base URL) to use for the Alliance Literature Service API.
+# Used to add an element in the metaData object of the output json file and in the curl command used when in test mode.
+my $api_endpoint = 'curation_status';
+
 
 
 if ($ENV_STATE eq "test") {
@@ -192,10 +196,6 @@ if ($ENV_STATE eq "test") {
 		die "Processing has been cancelled.\n";
 
 	}
-
-	print STDERR "okta token:";
-	$okta_token = <STDIN>;
-	chomp $okta_token;
 
 }
 
@@ -1132,7 +1132,7 @@ foreach my $flag_type (keys %{$diseaseHP_types}) {
 
 unless ($ENV_STATE eq "test") {
 
-	my $json_metadata = &make_abc_json_metadata($db);
+	my $json_metadata = &make_abc_json_metadata($db, $api_endpoint);
 
 	$complete_data->{"metaData"} = $json_metadata;
 	my $complete_json_data = $json_encoder->encode($complete_data);
@@ -1148,7 +1148,7 @@ unless ($ENV_STATE eq "test") {
 		my $json_element = $json_encoder->encode($element);
 
 
-		my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/curation_status/'  -H 'accept: application/json'  -H 'Authorization: Bearer $okta_token' -H 'Content-Type: application/json'  -d '$json_element'";
+		my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_element'";
 		my $raw_result = `$cmd`;
 		my $result = $json_encoder->decode($raw_result);
 

--- a/populate_topic_data.pl
+++ b/populate_topic_data.pl
@@ -37,7 +37,7 @@ Used to load FlyBase triage flag information into the Alliance ABC literature da
 
 =head1 USAGE
 
-USAGE: perl ticket_scrum-3147-topic-entity-tag.pl pg_server db_name pg_username pg_password dev|test|stage|production okta_token
+USAGE: perl ticket_scrum-3147-topic-entity-tag.pl pg_server db_name pg_username pg_password dev|test|stage|production access_token
 
 
 =cut
@@ -129,7 +129,7 @@ Script logic:
 
 if (@ARGV != 6) {
     warn "Wrong number of arguments, should be 6!\n";
-    warn "\n USAGE: $0 pg_server db_name pg_username pg_password dev|test|stage|production okta_token\n\n";
+    warn "\n USAGE: $0 pg_server db_name pg_username pg_password dev|test|stage|production access_token\n\n";
     warn "\teg: $0 flysql24 production_chado zhou pwd dev|test|stage|production ABCD1234\n\n";
     exit;
 }
@@ -139,12 +139,12 @@ my $db = shift(@ARGV);
 my $user = shift(@ARGV);
 my $pwd = shift(@ARGV);
 my $ENV_STATE = shift(@ARGV);
-my $okta_token = shift(@ARGV);
+my $access_token = shift(@ARGV);
 
 
 my @STATE = ("dev", "test", "stage", "production");
 if (! grep( /^$ENV_STATE$/, @STATE ) ) {
-    warn "\n USAGE: $0 pg_server db_name pg_username pg_password dev|test|stage|production okta_token\n\n";
+    warn "\n USAGE: $0 pg_server db_name pg_username pg_password dev|test|stage|production access_token\n\n";
     warn "\teg: $0 flysql24 production_chado zhou pwd dev|test|stage|production ABCD1234\n\n";
     exit;
 }
@@ -191,6 +191,12 @@ if ($ENV_STATE eq "dev" || $ENV_STATE eq "test") {
 
 
 my $test_FBrf = '';
+
+
+# variable that specifies the appropriate path (downstream of the base URL) to use for the Alliance Literature Service API.
+# Used to add an element in the metaData object of the output json file and in the curl command used when in test mode.
+my $api_endpoint = 'topic_entity_tag';
+
 
 if ($ENV_STATE eq "dev" || $ENV_STATE eq "test") {
 
@@ -476,7 +482,7 @@ foreach my $pub_id (sort keys %{$flag_info}) {
 									push @{$complete_data->{data}}, $data;
 
 								} else {
-									my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/topic_entity_tag/'  -H 'accept: application/json'  -H 'Authorization: Bearer $okta_token' -H 'Content-Type: application/json'  -d '$json_data'";
+									my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_data'";
 									my $raw_result = `$cmd`;
 									my $result = $json_encoder->decode($raw_result);
 
@@ -722,7 +728,7 @@ foreach my $pub_id (sort keys %{$dataset_pheno_data}) {
 
 			my $json_data = $json_encoder->encode($data);
 
-			my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/topic_entity_tag/'  -H 'accept: application/json'  -H 'Authorization: Bearer $okta_token' -H 'Content-Type: application/json'  -d '$json_data'";
+			my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/topic_entity_tag/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_data'";
 			my $raw_result = `$cmd`;
 			my $result = $json_encoder->decode($raw_result);
 
@@ -755,7 +761,7 @@ foreach my $pub_id (sort keys %{$dataset_pheno_data}) {
 
 unless ($ENV_STATE eq "test") {
 
-	my $json_metadata = &make_abc_json_metadata($db);
+	my $json_metadata = &make_abc_json_metadata($db, $api_endpoint);
 	$complete_data->{"metaData"} = $json_metadata;
 	my $complete_json_data = $json_encoder->encode($complete_data);
 


### PR DESCRIPTION
This pull request does 3 things:

`lib/Util.pm` `make_abc_json_metadata` subroutine now adds a '**endpoint**' item to the **metaData** object in the json output file - this specifies what API endpoint should be used to load the data in the json output file into the ABC (relevant to Alliance SCRUM-5477)

`populate_topic_data.pl` and `populate_topic_curation_status.pl` - the same variable used to specify the appropriate endpoint when `make_abc_json_metadata` is called is also used in the curl command used in test mode (which tests actually loading data into stage ABC). I have tested that this works for both scripts.

`populate_topic_curation_status.pl` - the access token is now supplied as an argument