### PR TITLE
Fta 175

### DIFF
--- a/lib/Mappings.pm
+++ b/lib/Mappings.pm
@@ -5,7 +5,7 @@ use warnings;
 
 require Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT = qw(get_flag_mapping get_flags_to_ignore FB_to_ABC_curator_mapping);
+our @EXPORT = qw(get_flag_mapping get_flags_to_ignore);
 
 use JSON::PP;
 
@@ -467,27 +467,3 @@ sub get_flags_to_ignore {
 
 
 
-sub FB_to_ABC_curator_mapping {
-
-
-=head1
-
-	Title:    FB_to_ABC_curator_mapping
-	Usage:    FB_to_ABC_curator_mapping()
-	Function: Returns a mapping of FB curator names to the corresponding ABC name for the small number of cases where the ABC curator name is not identical to the FB one.
-	Example:  my $FB_to_ABC_curator_mapping = &FB_to_ABC_curator_mapping();
-	Args   :  none
-
-=cut
-
-
-	my $cur_mapping = {
-
-		'Author Submission' => 'FB Author Submission',
-		'User Submission' => 'FB User Submission',
-		'Virtual Fly Brain' => 'FB Virtual Fly Brain',
-
-	};
-
-	return $cur_mapping;
-}

--- a/lib/Mappings.pm
+++ b/lib/Mappings.pm
@@ -5,7 +5,7 @@ use warnings;
 
 require Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT = qw(get_flag_mapping get_flags_to_ignore);
+our @EXPORT = qw(get_flag_mapping get_flags_to_ignore FB_to_ABC_curator_mapping);
 
 use JSON::PP;
 
@@ -463,4 +463,31 @@ sub get_flags_to_ignore {
 
 
 
+}
+
+
+
+sub FB_to_ABC_curator_mapping {
+
+
+=head1
+
+	Title:    FB_to_ABC_curator_mapping
+	Usage:    FB_to_ABC_curator_mapping()
+	Function: Returns a mapping of FB curator names to the corresponding ABC name for the small number of cases where the ABC curator name is not identical to the FB one.
+	Example:  my $FB_to_ABC_curator_mapping = &FB_to_ABC_curator_mapping();
+	Args   :  none
+
+=cut
+
+
+	my $cur_mapping = {
+
+		'Author Submission' => 'FB Author Submission',
+		'User Submission' => 'FB User Submission',
+		'Virtual Fly Brain' => 'FB Virtual Fly Brain',
+
+	};
+
+	return $cur_mapping;
 }

--- a/lib/Util.pm
+++ b/lib/Util.pm
@@ -5,7 +5,7 @@ use warnings;
 
 require Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT = qw(make_abc_json_metadata get_yyyymmdd_date_stamp pub_has_curated_data get_relevant_curator_from_candidate_list get_relevant_curator_from_candidate_list_using_pub_and_timestamp check_and_validate_nocur clean_note);
+our @EXPORT = qw(make_abc_json_metadata get_yyyymmdd_date_stamp pub_has_curated_data get_relevant_curator_from_candidate_list get_relevant_curator_from_candidate_list_using_pub_and_timestamp check_and_validate_nocur clean_note convert_curator_names_for_single_element convert_curator_names_bulk);
 
 use JSON::PP;
 
@@ -719,3 +719,101 @@ sub degreek {
 
 }
 
+sub convert_curator_names_bulk {
+
+
+=head1
+
+	Title:    convert_curator_names_bulk
+	Function: Takes a hash that contains an array of elements, where each element represent a single data item to be submitted to the ABC, and for each element converts curator names in any created_by or updated_by keys in the element to the corresponding ABC curator name (for the small number of cases where the ABC curator name is not identical to the FB curator name). Designed for use in any mode other than test where all data is gathered in a single hash of array elements before converting to a single json file.
+	Example:  my $complete_data = &convert_curator_names_bulk($complete_data);
+	Args   :  none
+
+=cut
+
+
+	my $cur_mapping = {
+
+		'Author Submission' => 'FB Author Submission',
+		'User Submission' => 'FB User Submission',
+		'Virtual Fly Brain' => 'FB Virtual Fly Brain',
+
+	};
+
+	unless (@_ == 1) {
+
+		die "Wrong number of parameters passed to the convert_curator_names_bulk subroutine\n";
+	}
+
+
+	my ($data) =  @_;
+
+	foreach my $element (@{$data}) {
+
+		my @fields_to_convert = ('created_by', 'updated_by');
+
+		foreach my $field (@fields_to_convert) {
+
+			if (exists $element->{$field}) {
+
+				if (exists $cur_mapping->{"$element->{$field}"}) {
+
+					my $converted_curator = $cur_mapping->{"$element->{$field}"};
+
+					$element->{$field} = "$converted_curator";
+				}
+			}
+		}
+	}
+
+	return $data;
+}
+
+
+sub convert_curator_names_for_single_element {
+
+
+=head1
+
+	Title:    convert_curator_names_for_single_element
+	Function: Takes a hash and converts curator names in any created_by or updated_by keys in the hash to the corresponding ABC curator name (for the small number of cases where the ABC curator name is not identical to the FB curator name). Designed for use in test mode when submitting single json elements at a time to ABC.
+	Example:  my $data = &convert_curator_names_for_single_element($data);
+	Args   :  none
+
+=cut
+
+
+	my $cur_mapping = {
+
+		'Author Submission' => 'FB Author Submission',
+		'User Submission' => 'FB User Submission',
+		'Virtual Fly Brain' => 'FB Virtual Fly Brain',
+
+	};
+
+	unless (@_ == 1) {
+
+		die "Wrong number of parameters passed to the convert_curator_names_for_single_element subroutine\n";
+	}
+
+
+	my ($data) =  @_;
+
+
+	my @fields_to_convert = ('created_by', 'updated_by');
+
+	foreach my $field (@fields_to_convert) {
+
+		if (exists $data->{$field}) {
+
+			if (exists $cur_mapping->{"$data->{$field}"}) {
+
+				my $converted_curator = $cur_mapping->{"$data->{$field}"};
+
+				$data->{$field} = "$converted_curator";
+			}
+		}
+	}
+
+	return $data;
+}

--- a/populate_topic_curation_status.pl
+++ b/populate_topic_curation_status.pl
@@ -1576,7 +1576,8 @@ foreach my $flag_type (keys %{$diseaseHP_types}) {
 
 # convert stored data into json for submitting to the Alliance
 
-
+# first convert any curator names as needed
+$complete_data->{data} = &convert_curator_names_bulk($complete_data->{data});
 
 
 unless ($ENV_STATE eq "test") {

--- a/populate_topic_data.pl
+++ b/populate_topic_data.pl
@@ -547,7 +547,6 @@ foreach my $pub_id (sort keys %{$flag_info}) {
 								}
 
 
-								my $json_data = $json_encoder->encode($data);
 
 								# plain text output useful for testing
 								print $plain_output_file "DATA: $FBrf\t$flag_type\t$flag\t$curator\t$currecs\t$flag_audit_timestamp\t$reformatted_note\n";
@@ -557,6 +556,9 @@ foreach my $pub_id (sort keys %{$flag_info}) {
 									push @{$complete_data->{data}}, $data;
 
 								} else {
+
+									my $json_data = $json_encoder->encode($data);
+
 									my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_data'";
 									my $raw_result = `$cmd`;
 									my $result = $json_encoder->decode($raw_result);
@@ -763,7 +765,7 @@ foreach my $pub_id (sort keys %{$topic_notes->{'ATP:0000085'}}) {
 		push @{$complete_data->{data}}, $data->{json};
 
 	} else {
-		my $json_data = $json_encoder->encode($data);
+		my $json_data = $json_encoder->encode($data->{json});
 
 		my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_data'";
 		my $raw_result = `$cmd`;

--- a/populate_topic_data.pl
+++ b/populate_topic_data.pl
@@ -556,6 +556,7 @@ foreach my $pub_id (sort keys %{$flag_info}) {
 									push @{$complete_data->{data}}, $data;
 
 								} else {
+									$data = &convert_curator_names_for_single_element($data);
 
 									my $json_data = $json_encoder->encode($data);
 
@@ -765,6 +766,8 @@ foreach my $pub_id (sort keys %{$topic_notes->{'ATP:0000085'}}) {
 		push @{$complete_data->{data}}, $data->{json};
 
 	} else {
+
+		$data->{json} = &convert_curator_names_for_single_element($data->{json});
 		my $json_data = $json_encoder->encode($data->{json});
 
 		my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_data'";
@@ -787,6 +790,7 @@ foreach my $pub_id (sort keys %{$topic_notes->{'ATP:0000085'}}) {
 
 unless ($ENV_STATE eq "test") {
 
+	$complete_data->{data} = &convert_curator_names_bulk($complete_data->{data});
 	my $json_metadata = &make_abc_json_metadata($db, $api_endpoint);
 	$complete_data->{"metaData"} = $json_metadata;
 	my $complete_json_data = $json_encoder->encode($complete_data);

--- a/populate_workflow_status.pl
+++ b/populate_workflow_status.pl
@@ -885,6 +885,8 @@ foreach my $pub_id (sort keys %{$workflow_status_data}) {
 
 #print Dumper ($complete_data);
 
+# convert any curator names as needed
+$complete_data->{data} = &convert_curator_names_bulk($complete_data->{data});
 
 unless ($ENV_STATE eq "test") {
 


### PR DESCRIPTION
Code to enable conversion of FB curator names to corresponding ABC curator names (in created_by and updated_by elements of data) when needed.

Strategy:
- Made conversion subroutines (Util.pm) containing mapping of names that need to be changed so can easily be updated if needed.
- Added conversion to the following scripts so that the final json will contain the correct ABC names:
      - populate_workflow_status.pl
      - populate_topic_curation_status.pl
      - populate_topic_data.pl

-  The scripts call the `convert_curator_names_bulk` subroutine once all data has been stored and do the conversion at the end, just before it is converted to json (so did not have to change any calls to chado in other parts of the script/lib modules)
- for populate_topic_data.pl I *also* had to add a `convert_curator_names_for_single_element` conversion for test mode, again just before the test json is submitted to the ABC, as that script is older and stores the data slightly differently 

