### PR TITLE
Script to make JSON file for loading FB historic text-mining topic results (from SVM)

### DIFF
--- a/lib/ABCInfo.pm
+++ b/lib/ABCInfo.pm
@@ -63,7 +63,8 @@ o access_token: access token for the relevant Alliance REST API service that was
 
 		'curator' => {
 
-			'evidence' => '0000036',
+			'evidence_prefix' => 'ATP',
+			'evidence_id' => '0000036',
 			'source_method' => 'FlyBase_curation',
 
 		},
@@ -71,16 +72,28 @@ o access_token: access token for the relevant Alliance REST API service that was
 
 		'author' => {
 
-			'evidence' => '0000035',
+			'evidence_prefix' => 'ATP',
+			'evidence_id' => '0000035',
 			'source_method' => 'author_first_pass',
 
 		},
+
+# For SVM results, use: ECO:0008019 = 'support vector machine evidence used in automatic assertion'
+
+		'svm' => {
+
+			'evidence_prefix' => 'ECO',
+			'evidence_id' => '0008019',
+			'source_method' => 'fb_svm_classifier',
+
+		},
+
 
 	};
 
 	unless (exists $curator_type_mapping->{$curator_type}) {
 
-		die "unrecognized value ($curator_type) passed to get_topic_entity_tag_source_data subroutine as curator_type: must be 'curator' or 'author'\n";
+		die "unrecognized value ($curator_type) passed to get_topic_entity_tag_source_data subroutine as curator_type: add details to the curator_type_mapping hash to be able to get this data from the ABC\n";
 
 
 	}
@@ -89,11 +102,11 @@ o access_token: access token for the relevant Alliance REST API service that was
 
 	if ($API_type eq 'stage') {
 
-		$cmd = "curl -X 'GET' 'https://stage-literature-rest.alliancegenome.org/topic_entity_tag/source/ATP%3A$curator_type_mapping->{$curator_type}->{evidence}/$curator_type_mapping->{$curator_type}->{source_method}/FB/FB' -H 'accept: application/json' -H 'Authorization: Bearer $access_token'";
+		$cmd = "curl -X 'GET' 'https://stage-literature-rest.alliancegenome.org/topic_entity_tag/source/$curator_type_mapping->{$curator_type}->{evidence_prefix}%3A$curator_type_mapping->{$curator_type}->{evidence_id}/$curator_type_mapping->{$curator_type}->{source_method}/FB/FB' -H 'accept: application/json' -H 'Authorization: Bearer $access_token'";
 
 	} else {
 
-		$cmd = "curl -X 'GET' 'https://literature-rest.alliancegenome.org/topic_entity_tag/source/ATP%3A$curator_type_mapping->{$curator_type}->{evidence}/$curator_type_mapping->{$curator_type}->{source_method}/FB/FB' -H 'accept: application/json' -H 'Authorization: Bearer $access_token'";
+		$cmd = "curl -X 'GET' 'https://literature-rest.alliancegenome.org/topic_entity_tag/source/$curator_type_mapping->{$curator_type}->{evidence_prefix}%3A$curator_type_mapping->{$curator_type}->{evidence_id}/$curator_type_mapping->{$curator_type}->{source_method}/FB/FB' -H 'accept: application/json' -H 'Authorization: Bearer $access_token'";
 
 	}
 

--- a/lib/ABCInfo.pm
+++ b/lib/ABCInfo.pm
@@ -157,7 +157,7 @@ o Corresponding AGRKB number.
 
 	my ($API_type, $FBrf) = @_;
 
-	unless ($API_type eq 'production' | $API_type eq 'stage') {
+	unless ($API_type eq 'production' || $API_type eq 'stage') {
 
 		die "unrecognized value ($API_type) passed to get_AGRKB_for_FBrf surboutine as API_type: must be 'production' or 'stage'\n";
 

--- a/populate_svm_topic_data.pl
+++ b/populate_svm_topic_data.pl
@@ -112,6 +112,20 @@ my $confidence_mapping = {
 
 };
 
+# mapping of confidence levels to scores
+my $score_mapping = {
+
+
+	'HIGH' => 0.9,
+	'MEDIUM' => 0.75,
+	'LOW' => 0.5,
+	'NEG' => 0,
+
+
+
+
+};
+
 
 my $month_mapping = {
 
@@ -328,6 +342,8 @@ foreach my $FBrf (sort keys %{$svm_data}) {
 
 
 					$data_element->{confidence_level} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence};
+					my $confidence_score = $score_mapping->{"$svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence}"};
+					$data_element->{confidence_score} = $confidence_score;
 
 
 					unless ($ENV_STATE eq "test") {

--- a/populate_svm_topic_data.pl
+++ b/populate_svm_topic_data.pl
@@ -271,7 +271,6 @@ foreach my $textmining_file (@textmining_files) {
 
 				} else {
 
-					#print $data_error_file "ERROR: no mapping in the flag_mapping hash for this flag_type:$flag from $flag_type, line: $_\n";
 					warn "ERROR: no mapping in the flag_mapping hash for this flag_type:$flag from $flag_type, line: $_\n";
 				}
 

--- a/populate_svm_topic_data.pl
+++ b/populate_svm_topic_data.pl
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 
-use DBI;
 use JSON::PP;
 
 use File::Basename;
@@ -20,7 +19,6 @@ use Util;
 use Data::Dumper;
 $Data::Dumper::Sortkeys = 1;
 
-use Encode;
 binmode(STDOUT, ":utf8");
 
 
@@ -31,7 +29,7 @@ use constant TRUE => \1;
 
 =head1 SYNOPSIS
 
-Used to load FlyBase SVM pipeline triage flag information into the Alliance ABC literature database as topic data. Generates an output file containing a single json structure for all the data (topic data is a set of arrays within a 'data' object, plus there is a 'metaData' object to indicate source and intended destination database).
+Used to load FlyBase SVM pipeline triage flag information into the Alliance ABC literature database as topic data. Generates a single json structure (printed to STDOUT) for all the data (topic data is a set of arrays within a 'data' object, plus there is a 'metaData' object to indicate source and intended destination database).
 
 =cut
 
@@ -46,14 +44,14 @@ USAGE: perl populate_svm_topic_data.pl folder_path dev|test|production XXXX
 if (@ARGV != 3) {
     warn "Wrong number of arguments, should be 3!\n";
     warn "\n USAGE: $0 folder_path dev|test|production access_token\n\n";
-    exit;
+    exit 1;
 }
 
 my $folder_path = shift(@ARGV);
 my $ENV_STATE = shift(@ARGV);
 my $access_token = shift(@ARGV);
 
-unless ($ENV_STATE eq 'dev'|| $ENV_STATE eq 'test'|| $ENV_STATE eq 'production') {
+unless ($ENV_STATE eq 'dev' || $ENV_STATE eq 'test'|| $ENV_STATE eq 'production') {
 
 	warn "Unknown state '$ENV_STATE': must be 'dev', 'test' or 'production'\n\n";
 	exit;
@@ -69,7 +67,7 @@ if ($ENV_STATE eq "test") {
 	chomp $continue;
 	if (($continue eq 'y') || ($continue eq 'Y')) {
 		print STDERR "Processing will continue.";
-	} else{
+	} else {
 		die "Processing has been cancelled.";
 	}
 }
@@ -83,13 +81,11 @@ if ($ENV_STATE eq "test") {
 	$test_FBrf = <STDIN>;
 	chomp $test_FBrf;
 
-	if ($ENV_STATE eq "test") {
 
-		unless ($test_FBrf =~ m/^FBrf[0-9]{7}$/) {
+	unless ($test_FBrf =~ m/^FBrf[0-9]{7}$/) {
 
-			die "Only a single FBrf is allowed in test mode."
+		die "Only a single FBrf is allowed in test mode."
 
-		}
 	}
 
 }
@@ -162,6 +158,9 @@ if ($ENV_STATE eq "dev" || $ENV_STATE eq "test") {
 	$svm_source_data = &get_topic_entity_tag_source_data($ENV_STATE, 'svm', $access_token);
 
 }
+
+die "Could not retrieve SVM topic_entity_tag_source_id from ABC — check token / that the source is configured.\n"
+    unless $svm_source_data->{topic_entity_tag_source_id};
 
 #print Dumper ($svm_source_data);
 

--- a/populate_svm_topic_data.pl
+++ b/populate_svm_topic_data.pl
@@ -288,65 +288,72 @@ foreach my $FBrf (sort keys %{$svm_data}) {
 			if ($svm_data->{$FBrf}->{$flag_type}->{$flag}->{count} == 1) {
 
 
-				# first store variables in a $data_element hash so it is easy to convert to correct json format later (and to add/change json structure if Alliance model changes)
-				my $data_element = {};
-				my $FBrf_with_prefix="FB:$FBrf";
-				$data_element->{reference_curie} = $FBrf_with_prefix;
-
-				if ($svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp}) {
-
-					$data_element->{date_created} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp};
-					$data_element->{date_updated} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp};
-
-				}
-
-				# set other parameters for the flag based on $flag_mapping hash or set the relevant default if the key does not exist in the mapping hash for that flag
-				my $ATP = "$flag_mapping->{$flag_type}->{$flag}->{ATP_topic}";
-				$data_element->{topic} = $ATP;
-				$data_element->{species} = exists $flag_mapping->{$flag_type}->{$flag}->{species} ? $flag_mapping->{$flag_type}->{$flag}->{species} : 'NCBITaxon:7227';
-
-				if ($svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence} eq 'NEG') {
-
-					$data_element->{negated} = TRUE;
-
-				} else {
-
-					$data_element->{negated} = FALSE;
-				}
+				# do not submit negative results for pipelines that are looking for 'new' data of a particular type (new_al, new_transg)
+				# this is to match current policy for equivalent ABC pipelines. do the test here rather than in first pass that reads FB files
+				# so that any cases with data conflicts can still be excluded
+				unless (exists $flag_mapping->{$flag_type}->{$flag}->{data_novelty} && $svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence} eq 'NEG') {
 
 
-				$data_element->{data_novelty} = exists $flag_mapping->{$flag_type}->{$flag}->{data_novelty} ? $flag_mapping->{$flag_type}->{$flag}->{data_novelty} : 'ATP:0000335'; # if the mapping hash has no specific data novelty term set, the parent term (ATP:0000335 = 'data novelty') must be added for ABC validation purposes
 
-				$data_element->{topic_entity_tag_source_id} = $svm_source_data->{topic_entity_tag_source_id};
+					# first store variables in a $data_element hash so it is easy to convert to correct json format later (and to add/change json structure if Alliance model changes)
+					my $data_element = {};
+					my $FBrf_with_prefix="FB:$FBrf";
+					$data_element->{reference_curie} = $FBrf_with_prefix;
 
+					if ($svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp}) {
 
-				$data_element->{confidence_level} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence};
+						$data_element->{date_created} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp};
+						$data_element->{date_updated} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp};
 
+					}
 
-				unless ($ENV_STATE eq "test") {
-					push @{$complete_data->{data}}, $data_element;
+					# set other parameters for the flag based on $flag_mapping hash or set the relevant default if the key does not exist in the mapping hash for that flag
+					my $ATP = "$flag_mapping->{$flag_type}->{$flag}->{ATP_topic}";
+					$data_element->{topic} = $ATP;
+					$data_element->{species} = exists $flag_mapping->{$flag_type}->{$flag}->{species} ? $flag_mapping->{$flag_type}->{$flag}->{species} : 'NCBITaxon:7227';
 
-				} else {
+					if ($svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence} eq 'NEG') {
 
-					my $json_data = $json_encoder->encode($data_element);
-
-					my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_data'";
-					my $raw_result = `$cmd`;
-					my $result = $json_encoder->decode($raw_result);
-
-
-					
-					unless (exists $result->{'detail'}) {
-
-						print "json post success\nJSON:\n$json_data\n\n";
+						$data_element->{negated} = TRUE;
 
 					} else {
 
-						print "json post failed\nJSON:\n$json_data\nREASON:\n$raw_result\n#################################\n\n";
+						$data_element->{negated} = FALSE;
+					}
 
+
+					$data_element->{data_novelty} = exists $flag_mapping->{$flag_type}->{$flag}->{data_novelty} ? $flag_mapping->{$flag_type}->{$flag}->{data_novelty} : 'ATP:0000335'; # if the mapping hash has no specific data novelty term set, the parent term (ATP:0000335 = 'data novelty') must be added for ABC validation purposes
+
+					$data_element->{topic_entity_tag_source_id} = $svm_source_data->{topic_entity_tag_source_id};
+
+
+					$data_element->{confidence_level} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence};
+
+
+					unless ($ENV_STATE eq "test") {
+						push @{$complete_data->{data}}, $data_element;
+
+					} else {
+
+						my $json_data = $json_encoder->encode($data_element);
+
+						my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_data'";
+						my $raw_result = `$cmd`;
+						my $result = $json_encoder->decode($raw_result);
+
+
+					
+						unless (exists $result->{'detail'}) {
+
+							print "json post success\nJSON:\n$json_data\n\n";
+
+						} else {
+
+							print "json post failed\nJSON:\n$json_data\nREASON:\n$raw_result\n#################################\n\n";
+
+						}
 					}
 				}
-
 
 			}
 

--- a/populate_svm_topic_data.pl
+++ b/populate_svm_topic_data.pl
@@ -214,9 +214,13 @@ foreach my $textmining_file (@textmining_files) {
 
 				my $day = $1;
 				my $month = $2;
-
-				$month = "$month_mapping->{$month}";
 				my $year = $3;
+
+				if ($day =~ m/^[0-9]{1}$/) {
+
+					$day = '0' . "$day";
+				}
+				$month = "$month_mapping->{$month}";
 				$timestamp = "$year-$month-$day";
 
 			}

--- a/populate_svm_topic_data.pl
+++ b/populate_svm_topic_data.pl
@@ -1,0 +1,371 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use DBI;
+use JSON::PP;
+
+use File::Basename;
+use File::Spec;
+
+# add lib sub-folder containing modules into @INC
+use lib File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs($0)), 'lib');
+
+# add modules from lib-subfolder
+use ABCInfo;
+use Mappings;
+use Util;
+
+use Data::Dumper;
+$Data::Dumper::Sortkeys = 1;
+
+use Encode;
+binmode(STDOUT, ":utf8");
+
+
+use constant FALSE => \0;
+use constant TRUE => \1;
+
+=head1 NAME populate_svm_topic_data.pl
+
+=head1 SYNOPSIS
+
+Used to load FlyBase SVM pipeline triage flag information into the Alliance ABC literature database as topic data. Generates an output file containing a single json structure for all the data (topic data is a set of arrays within a 'data' object, plus there is a 'metaData' object to indicate source and intended destination database).
+
+=cut
+
+=head1 USAGE
+
+USAGE: perl populate_svm_topic_data.pl folder_path dev|test|production XXXX
+
+
+=cut
+
+
+if (@ARGV != 3) {
+    warn "Wrong number of arguments, should be 3!\n";
+    warn "\n USAGE: $0 folder_path dev|test|production access_token\n\n";
+    exit;
+}
+
+my $folder_path = shift(@ARGV);
+my $ENV_STATE = shift(@ARGV);
+my $access_token = shift(@ARGV);
+
+unless ($ENV_STATE eq 'dev'|| $ENV_STATE eq 'test'|| $ENV_STATE eq 'production') {
+
+	warn "Unknown state '$ENV_STATE': must be 'dev', 'test' or 'production'\n\n";
+	exit;
+
+}
+
+
+
+if ($ENV_STATE eq "test") {
+	print STDERR "You are about to write data to stage Alliance literature server\n";
+	print STDERR "Type y to continue else anything else to stop:\n";
+	my $continue = <STDIN>;
+	chomp $continue;
+	if (($continue eq 'y') || ($continue eq 'Y')) {
+		print STDERR "Processing will continue.";
+	} else{
+		die "Processing has been cancelled.";
+	}
+}
+
+my $test_FBrf = '';
+
+
+if ($ENV_STATE eq "test") {
+
+	print STDERR "FBrf to test:";
+	$test_FBrf = <STDIN>;
+	chomp $test_FBrf;
+
+	if ($ENV_STATE eq "test") {
+
+		unless ($test_FBrf =~ m/^FBrf[0-9]{7}$/) {
+
+			die "Only a single FBrf is allowed in test mode."
+
+		}
+	}
+
+}
+
+
+# variable that specifies the appropriate path (downstream of the base URL) to use for the Alliance Literature Service API.
+# Used to add an element in the metaData object of the output json file and in the curl command used when in test mode.
+my $api_endpoint = 'topic_entity_tag';
+
+my $json_encoder = JSON::PP->new()->pretty(1)->canonical(1);
+
+my $confidence_mapping = {
+
+	'high' => 'HIGH',
+	'medium' => 'MEDIUM',
+	'low' => 'LOW',
+	'neg' => 'NEG',
+
+
+
+};
+
+
+my $month_mapping = {
+
+
+	'Jan' => '01',
+	'Feb' => '02',
+	'Mar' => '03',
+	'Apr' => '04',
+	'May' => '05',
+	'Jun' => '06',
+	'Jul' => '07',
+	'Aug' => '08',
+	'Sep' => '09',
+	'Oct' => '10',
+	'Nov' => '11',
+	'Dec' => '12',
+
+
+
+};
+
+
+my $MONTHS = join '|', sort keys %{$month_mapping};
+
+# get source information for SVM from ABC
+my $svm_source_data = {};
+
+if ($ENV_STATE eq "dev" || $ENV_STATE eq "test") {
+
+	$svm_source_data = &get_topic_entity_tag_source_data('stage', 'svm', $access_token);
+
+} else {
+
+	$svm_source_data = &get_topic_entity_tag_source_data($ENV_STATE, 'svm', $access_token);
+
+}
+
+#print Dumper ($svm_source_data);
+
+
+# data structures for how/whether to map FB triage flags to corresponding ABC topic info
+my $flag_mapping = &get_flag_mapping();
+my $flags_to_ignore = &get_flags_to_ignore();
+
+
+
+unless (-e $folder_path) {
+
+	die "Exiting script: specified folder ($folder_path) does not exist.\n";
+
+}
+
+unless (-r $folder_path) {
+	die "Exiting script: Cannot read specified folder ($folder_path)\n";
+}
+
+unless (-d $folder_path) {
+	die "Exiting script: specified folder ($folder_path) is not a directory\n";
+}
+
+chdir $folder_path
+	or die "Exiting script: cannot change directory to specified folder ($folder_path) ($!)\n";
+
+
+my @textmining_files = glob "*_SVM.txt";
+
+
+
+
+
+my $svm_data = {};
+
+foreach my $textmining_file (@textmining_files) {
+
+	open my $input_file, '<', "$textmining_file"
+		or die "Can\'t open $textmining_file ($!)\n";
+
+	my $timestamp = '';
+
+	while (<$input_file>) {
+
+		if (m|^\#|) {
+
+
+			if (m/carried out on ([0-9]{1,2}) ($MONTHS) ([0-9]{4})/i) {
+
+				my $day = $1;
+				my $month = $2;
+
+				$month = "$month_mapping->{$month}";
+				my $year = $3;
+				$timestamp = "$year-$month-$day";
+
+			}
+
+		} elsif (m|^.*?\t(FBrf[0-9]{7})\t([0-9]{1,})?\t(.+?):(.+?)\t(.+?)\t?$|) {
+
+			if ($timestamp eq '') {
+				warn "$textmining_file: no timestamp set: $_";
+
+			}
+
+			my $FBrf = $1;
+			my $flag = $3;
+			my $confidence = $4;
+			my $flag_type = $5;
+			$flag_type = $flag_type . '_flag';
+
+			unless (exists $flags_to_ignore->{$flag_type} && exists $flags_to_ignore->{$flag_type}->{$flag}) {
+
+				if (exists $flag_mapping->{$flag_type} && exists $flag_mapping->{$flag_type}->{$flag}) {
+
+
+					if (exists $confidence_mapping->{$confidence}) {
+
+
+						unless ($test_FBrf) {
+
+
+							$svm_data->{$FBrf}->{$flag_type}->{$flag}->{count}++;
+							$svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence} = $confidence_mapping->{$confidence};
+							$svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp} = $timestamp;
+
+
+						} else {
+
+
+							if ($FBrf =~ m/$test_FBrf/) {
+
+								$svm_data->{$FBrf}->{$flag_type}->{$flag}->{count}++;
+								$svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence} = $confidence_mapping->{$confidence};
+								$svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp} = $timestamp;
+
+							}
+
+						}
+
+					} else {
+						warn "ERROR: no mapping in the confidence_mapping hash for the '$confidence' confidence level: $_\n";
+
+
+					}
+
+				} else {
+
+					#print $data_error_file "ERROR: no mapping in the flag_mapping hash for this flag_type:$flag from $flag_type, line: $_\n";
+					warn "ERROR: no mapping in the flag_mapping hash for this flag_type:$flag from $flag_type, line: $_\n";
+				}
+
+			}
+
+		} else {
+
+			warn "Non-matching line ($textmining_file): $_";
+
+		}
+
+
+	}
+
+	close $input_file;
+}
+
+#print Dumper ($svm_data);
+
+my $complete_data = {};
+
+
+foreach my $FBrf (sort keys %{$svm_data}) {
+	foreach my $flag_type (sort keys %{$svm_data->{$FBrf}}) {
+		foreach my $flag (sort keys %{$svm_data->{$FBrf}->{$flag_type}}) {
+
+			# only use flag+FBrf combinations with a single row in original files (to avoid any data conflicts)
+			if ($svm_data->{$FBrf}->{$flag_type}->{$flag}->{count} == 1) {
+
+
+				# first store variables in a $data_element hash so it is easy to convert to correct json format later (and to add/change json structure if Alliance model changes)
+				my $data_element = {};
+				my $FBrf_with_prefix="FB:$FBrf";
+				$data_element->{reference_curie} = $FBrf_with_prefix;
+
+				if ($svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp}) {
+
+					$data_element->{date_created} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp};
+					$data_element->{date_updated} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{timestamp};
+
+				}
+
+				# set other parameters for the flag based on $flag_mapping hash or set the relevant default if the key does not exist in the mapping hash for that flag
+				my $ATP = "$flag_mapping->{$flag_type}->{$flag}->{ATP_topic}";
+				$data_element->{topic} = $ATP;
+				$data_element->{species} = exists $flag_mapping->{$flag_type}->{$flag}->{species} ? $flag_mapping->{$flag_type}->{$flag}->{species} : 'NCBITaxon:7227';
+
+				if ($svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence} eq 'NEG') {
+
+					$data_element->{negated} = TRUE;
+
+				} else {
+
+					$data_element->{negated} = FALSE;
+				}
+
+
+				$data_element->{data_novelty} = exists $flag_mapping->{$flag_type}->{$flag}->{data_novelty} ? $flag_mapping->{$flag_type}->{$flag}->{data_novelty} : 'ATP:0000335'; # if the mapping hash has no specific data novelty term set, the parent term (ATP:0000335 = 'data novelty') must be added for ABC validation purposes
+
+				$data_element->{topic_entity_tag_source_id} = $svm_source_data->{topic_entity_tag_source_id};
+
+
+				$data_element->{confidence_level} = $svm_data->{$FBrf}->{$flag_type}->{$flag}->{confidence};
+
+
+				unless ($ENV_STATE eq "test") {
+					push @{$complete_data->{data}}, $data_element;
+
+				} else {
+
+					my $json_data = $json_encoder->encode($data_element);
+
+					my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_data'";
+					my $raw_result = `$cmd`;
+					my $result = $json_encoder->decode($raw_result);
+
+
+					
+					unless (exists $result->{'detail'}) {
+
+						print "json post success\nJSON:\n$json_data\n\n";
+
+					} else {
+
+						print "json post failed\nJSON:\n$json_data\nREASON:\n$raw_result\n#################################\n\n";
+
+					}
+				}
+
+
+			}
+
+		}
+	}
+}
+
+
+unless ($ENV_STATE eq "test") {
+
+	my $json_metadata = &make_abc_json_metadata('FB curation_data/text_mining_flags SVM files', $api_endpoint);
+	$complete_data->{"metaData"} = $json_metadata;
+	my $complete_json_data = $json_encoder->encode($complete_data);
+
+	print $complete_json_data;
+
+
+}
+
+
+
+

--- a/populate_topic_curation_status.pl
+++ b/populate_topic_curation_status.pl
@@ -50,10 +50,6 @@ o dev mode
 
   o single FBrf mode: asks user for FBrf number (can also use a regular expression to test multiple FBrfs in this mode).
 
-  o Data is printed to both the json output and 'plain' output files.
-
-  o makes error files (see below) to record any errors.
-
 
 o test mode
 
@@ -61,28 +57,23 @@ o test mode
 
   o uses curl to try to POST data to the Alliance ABC stage server (so asks user for okta token for Alliance ABC stage server).
 
-  o Data (including a record of successful curl POST events) is printed to the 'plain' output file.
-
-  o makes error files (see below) to record any errors.
-
 
 o production mode
 
   o makes data for all relevant FBrfs in chado.
 
-  o Data is printed to the json output file.
 
-  o makes error files (see below) to record any errors.
 
 
 o Output files
 
+  o The same four files are made in each mode:
 
-  o json output file (FB_curation_status_data.json) containing a single json structure for all the data (curation status data is a set of arrays within a 'data' object, plus there is a 'metaData' object to indicate source). Data is printed to this file in all modes except 'test'.
+  o json output file (FB_curation_status_data.json) - in all modes except 'test' contains a single json structure for all the data (curation status data is a set of arrays within a 'data' object, plus there is a 'metaData' object to indicate source). In test mode, successfully submitted json elements are printed in this file.
 
- o 'plain' output file (FB_curation_status_data.txt) to aid in debugging - prints the same information as in the json file, but in a more human-readable tsv format with a single row for each FBrf+topic combination, along with additional information useful for debugging. Data is printed to this file in all modes.
+ o 'plain' output file (FB_curation_status_data.txt) to aid in debugging - prints the same information as in the json file, but in a more human-readable tsv format with a single row for each FBrf+topic combination, along with additional information useful for debugging.
 
-  o FB_curation_status_data_errors.err - errors in mapping FlyBase data to appropriate Alliance json are printed in this file. Data is printed to this file in all modes.
+  o FB_curation_status_data_errors.err - errors in mapping FlyBase data to appropriate Alliance json are printed in this file.
 
   o FB_curation_status_process_errors.err - processing errors - if a curl POST fails in test mode, the failed json element and the reason for the failure are printed in this file. Expected to be empty for all other modes.
 
@@ -1602,9 +1593,9 @@ unless ($ENV_STATE eq "test") {
 		my $raw_result = `$cmd`;
 		my $result = $json_encoder->decode($raw_result);
 
-		if (exists $result->{'status'} && $result->{'status'} eq 'success') {
+		unless (exists $result->{'detail'}) {
 
-			print $plain_output_file "json post success\nJSON:\n$json_element\n\n";
+			print $json_output_file "json post success\nJSON:\n$json_element\n\n";
 
 		} else {
 

--- a/populate_topic_data.pl
+++ b/populate_topic_data.pl
@@ -566,7 +566,7 @@ foreach my $pub_id (sort keys %{$flag_info}) {
 
 
 
-									if (exists $result->{'status'} && $result->{'status'} eq 'success') {
+									unless (exists $result->{'detail'}) {
 
 										print $json_output_file "json post success\nJSON:\n$json_data\n\n";
 
@@ -774,7 +774,7 @@ foreach my $pub_id (sort keys %{$topic_notes->{'ATP:0000085'}}) {
 		my $raw_result = `$cmd`;
 		my $result = $json_encoder->decode($raw_result);
 
-		if (exists $result->{'status'} && $result->{'status'} eq 'success') {
+		unless (exists $result->{'detail'}) {
 
 			print $json_output_file "json post success\nJSON:\n$json_data\n\n";
 

--- a/populate_workflow_status.pl
+++ b/populate_workflow_status.pl
@@ -93,9 +93,6 @@ o dev mode
 
   o single FBrf mode: asks user for FBrf number (can also use a regular expression to test multiple FBrfs in this mode).
 
-  o Data is printed to both the json output and 'plain' output files.
-
-  o makes error files (see below) to record any errors.
 
 
 o test mode
@@ -104,28 +101,23 @@ o test mode
 
   o uses curl to try to POST data to the Alliance ABC stage server (so asks user for okta token for Alliance ABC stage server).
 
-  o Data (including a record of successful curl POST events) is printed to the 'plain' output file.
-
-  o makes error files (see below) to record any errors.
 
 
 o production mode
 
   o makes data for all relevant FBrfs in chado.
 
-  o Data is printed to the json output file.
-
-  o makes error files (see below) to record any errors.
 
 
 o Output files
 
+  o The same four files are made in each mode:
 
-  o json output file (FB_workflow_status_data.json) containing a single json structure for all the data (manual_indexing status data is a set of arrays within a 'data' object, plus there is a 'metaData' object to indicate source). Data is printed to this file in all modes except 'test'.
+  o json output file (FB_workflow_status_data.json) containing a single json structure for all the data (manual_indexing status data is a set of arrays within a 'data' object, plus there is a 'metaData' object to indicate source).  In test mode, successfully submitted json elements are printed in this file.
 
- o 'plain' output file (FB_workflow_status_data.txt) to aid in debugging - prints the same data as in the json file, but with a single 'DATA:' tsv row for each FBrf+topic combination. Data is printed to this file in all modes.
+ o 'plain' output file (FB_workflow_status_data.txt) to aid in debugging - prints the same data as in the json file, but with a single 'DATA:' tsv row for each FBrf+topic combination.
 
-  o FB_workflow_status_data_errors.err - errors in mapping FlyBase data to appropriate Alliance json are printed in this file. Data is printed to this file in all modes.
+  o FB_workflow_status_data_errors.err - errors in mapping FlyBase data to appropriate Alliance json are printed in this file.
 
   o FB_workflow_status_process_errors.err - processing errors - if a curl POST fails in test mode, the failed json element and the reason for the failure are printed in this file. Expected to be empty for all other modes.
 
@@ -908,12 +900,11 @@ unless ($ENV_STATE eq "test") {
 
 		my $cmd="curl -X 'POST' 'https://stage-literature-rest.alliancegenome.org/$api_endpoint/'  -H 'accept: application/json'  -H 'Authorization: Bearer $access_token' -H 'Content-Type: application/json'  -d '$json_element'";
 		my $raw_result = `$cmd`;
-
 		
-
+		# endpoint behaviour for success still returns an integer for workflow_tag endpoint
 		if ($raw_result =~ m/^\d+$/) {
 
-			print $plain_output_file "json post success\nJSON:\n$json_element\n\n";
+			print $json_output_file "json post success\nJSON:\n$json_element\n\n";
 
 		} else {
 


### PR DESCRIPTION
Changes to ABCInfo.pm - added new mapping to get_topic_entity_tag_source_data so can get metadata from ABC for submitting svm topic results


Changes to populate_topic_data.pl and populate_curation_status.pl were just updating test for curl POST success as data returned from APIs has changed

Main change is new populate_svm_topic_data.pl

- uses existing SVM tsv files to generate json for submitting FB svm data to ABC as topics

